### PR TITLE
Add `do-not-fetch-tags` to CloneOption for Git

### DIFF
--- a/jenkins_jobs/modules/scm.py
+++ b/jenkins_jobs/modules/scm.py
@@ -170,6 +170,8 @@ def git(registry, xml_parent, data):
         * **scm-name** (`string`) - The unique scm name for this Git SCM
             (optional)
         * **shallow-clone** (`bool`) - Perform shallow clone (default false)
+        * **do-not-fetch-tags** (`bool`) - Perform a clone without tags
+            (default false)
         * **sparse-checkout** (`dict`)
             * **paths** (`list`) - List of paths to sparse checkout. (optional)
         * **submodule** (`dict`)
@@ -373,10 +375,18 @@ def git(registry, xml_parent, data):
     if 'scm-name' in data:
         ext = XML.SubElement(exts_node, impl_prefix + 'ScmName')
         XML.SubElement(ext, 'name').text = str(data['scm-name'])
-    if 'shallow-clone' in data or 'timeout' in data:
+    clone_options = (
+        "shallow-clone",
+        "timeout",
+        "do-not-fetch-tags"
+    )
+    if any(key in data for key in clone_options):
         clo = XML.SubElement(exts_node, impl_prefix + 'CloneOption')
         XML.SubElement(clo, 'shallow').text = str(
             data.get('shallow-clone', False)).lower()
+        if 'do-not-fetch-tags' in data:
+            XML.SubElement(clo, 'noTags').text = str(
+                data.get('do-not-fetch-tags', False)).lower()
         if 'timeout' in data:
             XML.SubElement(clo, 'timeout').text = str(data['timeout'])
     if 'sparse-checkout' in data:

--- a/tests/scm/fixtures/git-cloneoptions01.xml
+++ b/tests/scm/fixtures/git-cloneoptions01.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <scm class="hudson.plugins.git.GitSCM">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/heads/*:refs/remotes/origin/*</refspec>
+        <url>https://github.com/openstack-infra/jenkins-job-builder.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>master</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <disableSubmodules>false</disableSubmodules>
+    <recursiveSubmodules>false</recursiveSubmodules>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <remotePoll>false</remotePoll>
+    <gitTool>Default</gitTool>
+    <submoduleCfg class="list"/>
+    <reference/>
+    <gitConfigName/>
+    <gitConfigEmail/>
+    <extensions>
+      <hudson.plugins.git.extensions.impl.CloneOption>
+        <shallow>false</shallow>
+        <noTags>true</noTags>
+      </hudson.plugins.git.extensions.impl.CloneOption>
+      <hudson.plugins.git.extensions.impl.WipeWorkspace/>
+    </extensions>
+  </scm>
+</project>

--- a/tests/scm/fixtures/git-cloneoptions01.yaml
+++ b/tests/scm/fixtures/git-cloneoptions01.yaml
@@ -1,0 +1,6 @@
+scm:
+  - git:
+      url: https://github.com/openstack-infra/jenkins-job-builder.git
+      branches:
+        - master
+      do-not-fetch-tags: true


### PR DESCRIPTION
**Addng `no-tags` to CloneOption**

In one of the recent change to Git plugin behavior[1], tags are
also search as part of branches.

This cause projects that build on all branches to also build on all
tags.

This change allowing for tags to be ignored. The correct XML setting for
this will need to be as follow.

```
    <extensions>
      <hudson.plugins.git.extensions.impl.CloneOption>
        <shallow>false</shallow>
        <noTags>true</noTags>
      </hudson.plugins.git.extensions.impl.CloneOption>
    </extensions>
```

This is the generated result

```
    <extensions>
      <hudson.plugins.git.extensions.impl.CloneOption>
        <shallow>false</shallow>
        <noTags>true</noTags>
      </hudson.plugins.git.extensions.impl.CloneOption>
      <hudson.plugins.git.extensions.impl.WipeWorkspace/>
    </extensions>
```

[1] jenkinsci/git-plugin#340
[2] jenkinsci/git-plugin@bfeda3e